### PR TITLE
Add a task to install bats-core automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.6.2 (2022-Jun-22)
+
+* #8 provide a task to install bats-core for local development
+
 ### 1.6.1 (2022-Apr-25)
 
 * terraform 1.0.10

--- a/README.md
+++ b/README.md
@@ -62,24 +62,21 @@ So that packer-dojo and terraform-dojo are similar and thus easier to maintain.
 
 Full spec is [ops-base](https://github.com/kudulab/ops-base)
 
-### Lifecycle
-1. In a feature branch:
- * you make changes
- * and run tests:
-     * `./tasks build`
-     * `./tasks itest`
-1. You decide that your changes are ready and you:
- * merge into master branch
- * run locally:
-   * `./tasks set_version` to set version in CHANGELOG, bump patch version
-   * e.g. `./tasks set_version 1.2.3` to set version in CHANGELOG to 1.2.3
- * push to master onto private git server
-1. CI server (GoCD) tests and releases.
 
+## Contributing
+Instructions how to update this project.
+
+1. Create a new feature branch from the main branch
+1. Work on your changes in that feature branch. If you want, describe you changes in [CHANGELOG.md](CHANGELOG.md)
+1. Build your image locally to check that it succeeds: `./tasks build_local`
+1. Test your image locally: `./tasks itest`. You may need to install the test framework - you can do it with `sudo ./tasks install_bats`
+1. If you are happy with the results, create a PR from your feature branch to master branch
+
+After this, someone will read your PR, merge it and ensure version bump (using `./tasks set_version`). CI pipeline will run to automatically build and test docker image, release the project and publish the docker image.
 
 ## License
 
-Copyright 2019 Ewa Czechowska, Tomasz Sętkowski
+Copyright 2019-2022 Ewa Czechowska, Tomasz Sętkowski
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tasks
+++ b/tasks
@@ -66,6 +66,22 @@ case "${command}" in
       ./tasks build_local
       docker_ops::push "${image_dir}" "${imagerc_filename}"
       ;;
+  install_bats)
+      # please run this task with root privileges (with sudo)
+      BATS_CORE_VERSION=1.2.1
+      cd /tmp && git clone --depth 1 -b v${BATS_CORE_VERSION} https://github.com/bats-core/bats-core.git
+      cd bats-core && ./install.sh /opt
+      cd .. && rm -r bats-core
+      ln -s /opt/bin/bats /usr/bin/bats
+
+      BATS_SUPPORT_VERSION=004e707638eedd62e0481e8cdc9223ad471f12ee
+      git clone https://github.com/ztombol/bats-support.git /opt/bats-support
+      cd /opt/bats-support && git reset --hard ${BATS_SUPPORT_VERSION}
+
+      BATS_ASSERT_VERSION=9f88b4207da750093baabc4e3f41bf68f0dd3630
+      git clone https://github.com/ztombol/bats-assert.git /opt/bats-assert
+      cd  /opt/bats-assert && git reset --hard ${BATS_ASSERT_VERSION}
+      ;;
   itest)
       docker_ops::ensure_pulled_image "${image_dir}" "${imagerc_filename}"
       echo "Testing image: ${KUDU_DOCKER_IMAGE_URL}"

--- a/test/integration/test_dojo_work/aws_ec2/versions.tf
+++ b/test/integration/test_dojo_work/aws_ec2/versions.tf
@@ -4,15 +4,15 @@ terraform {
 
   required_providers {
     aws = {
-      version = "~> 3.75.1"
+      version = "= 3.75.1"
     }
     null = {
-      version = "~> 3.1.1"
+      version = "= 3.1.1"
     }
     # Simply for the sake of verification
     openstack = {
       source  = "terraform-provider-openstack/openstack"
-      version = "~> 1.42.0"
+      version = "= 1.42.0"
     }
   }
 }


### PR DESCRIPTION
We use bats-core, bats-assert, and bats-support to test docker-terraform-dojo. This PR provides an automated way to set them up on a local workstation

This aims to fix https://github.com/kudulab/docker-terraform-dojo/issues/8